### PR TITLE
Added update on page change functionality

### DIFF
--- a/app/assets/javascripts/components/submit_button.cjsx
+++ b/app/assets/javascripts/components/submit_button.cjsx
@@ -8,4 +8,4 @@ module.exports = class SubmitButton extends React.Component
     </div>
 
   saveReport: =>
-    QuestionnaireStore.saveAll()
+    QuestionnaireStore.submitReport()

--- a/app/assets/javascripts/stores/questionnaire_store.cjsx
+++ b/app/assets/javascripts/stores/questionnaire_store.cjsx
@@ -4,9 +4,14 @@ require('whatwg-fetch')
 class QuestionnaireStore extends EventEmitter
   CHANGE_EVENT = "change"
   VISIBILITY_EVENT = "visibility"
+  PAGE_CHANGE_EVENT = "page_change"
 
+  reportId      = null
   currentPage   = 0
   questionnaire = {}
+
+  constructor: ->
+    @on(PAGE_CHANGE_EVENT, @saveOrUpdateReport)
 
   currentPage: ->
     currentPage
@@ -14,10 +19,12 @@ class QuestionnaireStore extends EventEmitter
   previousPage: ->
     currentPage -= 1
     @emit(CHANGE_EVENT)
+    @emit(PAGE_CHANGE_EVENT)
 
   nextPage: ->
     currentPage += 1
     @emit(CHANGE_EVENT)
+    @emit(PAGE_CHANGE_EVENT)
 
   load: (data) ->
     questionnaire = data
@@ -67,7 +74,10 @@ class QuestionnaireStore extends EventEmitter
   addVisibilityListener: (callback) =>
     @on(VISIBILITY_EVENT, callback)
 
-  saveAll: =>
+  saveOrUpdateReport: =>
+    if reportId? then @updateReport() else @saveReport()
+
+  saveReport: =>
     token = document.getElementsByName("csrf-token")[0].content
     fetch('/reports', {
       method: 'POST',
@@ -79,7 +89,25 @@ class QuestionnaireStore extends EventEmitter
       credentials: 'include',
       body: JSON.stringify({ report: { data: questionnaire }})
     }).then((response) ->
-      window.location = response.headers.get('Location')
+      response.json().then((json) ->
+        reportId = json.id
+      )
     )
+
+  updateReport: =>
+    token = document.getElementsByName("csrf-token")[0].content
+    fetch("/reports/#{reportId}", {
+      method: 'PUT',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+        'X-CSRF-Token': token
+      },
+      credentials: 'include',
+      body: JSON.stringify({ report: { data: questionnaire }})
+    })
+
+  submitReport: =>
+    alert("Report marked as submitted")
 
 module.exports = new QuestionnaireStore()

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -8,11 +8,26 @@ class ReportsController < ApplicationController
   end
 
   def create
-    @report = Report.new(data: params.require(:report)[:data])
+    @report = Report.new(report_params)
     if @report.save
-      head :created, location: reports_path
+      #head :created, location: reports_path
+      render json: @report
     else
       head 422, location: reports_path
     end
   end
+
+  def update
+    @report = Report.find(params[:id])
+    if @report.update(report_params)
+      render json: @report
+    else
+      head 422, location: reports_path
+    end
+  end
+
+  private
+    def report_params
+      {data: params.require(:report)[:data]}
+    end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
 
-  resources :reports, only: [:index, :new, :create]
+  resources :reports, only: [:index, :new, :create, :update]
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".


### PR DESCRIPTION
Report will now be committed to the database on the first page change event. Subsequent page change events will update that existing report in the database. Submit button just renders an alert for now, paving the way for the ability to 'mark questionnaire as completed'. 🐵