### PR TITLE
feat: basic implementation of multi-file uploads

### DIFF
--- a/app/controllers/bulk_uploads_controller.rb
+++ b/app/controllers/bulk_uploads_controller.rb
@@ -31,13 +31,19 @@ class BulkUploadsController < ApplicationController
   end
 
   def create
-    redirect_to(:back) and return if params[:file].nil?
+    redirect_to(:back) and return if params[:files].nil?
 
-    result = CsvImporter.import(params[:file].path)
-    if result[:successful]
-      redirect_to BulkUpload.create(result), flash: {success: t("bulk_uploads.upload_successful")}
-    else
-      redirect_to BulkUpload.create(result), flash: {error: t("bulk_uploads.upload_error")}
+    params[:files].each_with_index do |file, index|
+      result = CsvImporter.import(file.path)
+      
+      if result[:successful]
+        BulkUpload.create(result)
+        
+        next if params[:files][index+1]
+        redirect_to bulk_uploads_path flash: {success: t("bulk_uploads.upload_successful")}
+      else
+        redirect_to BulkUpload.create(result), flash: {error: t("bulk_uploads.upload_error")}
+      end
     end
   end
 

--- a/app/controllers/bulk_uploads_controller.rb
+++ b/app/controllers/bulk_uploads_controller.rb
@@ -1,53 +1,87 @@
+# frozen_string_literal: true
+
 class BulkUploadsController < ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
 
-  def show
-  end
+  def show; end
 
   def index
     @bulk_uploads = BulkUpload.includes(:reports).order(:created_at).page(params[:page])
   end
 
-  def new
-  end
+  def new; end
 
   def edit
-    @bulk_upload = BulkUpload.find(params[:id]) or raise_404
+    (@bulk_upload = BulkUpload.find(params[:id])) || raise_404
   end
 
   def update
-    redirect_to(:back) and return if params[:file].nil?
+    redirect_to(:back) && return if params[:file].nil?
 
     result = CsvImporter.import(params[:file].path)
-    @bulk_upload = BulkUpload.find(params[:id]) or raise_404
+    (@bulk_upload = BulkUpload.find(params[:id])) || raise_404
     @bulk_upload.update(result)
 
     if result[:successful]
-      redirect_to @bulk_upload, flash: {success: t("bulk_uploads.upload_successful")}
+      redirect_to @bulk_upload, flash: { success: t('bulk_uploads.upload_successful') }
     else
-      redirect_to @bulk_upload, flash: {error: t("bulk_uploads.upload_error")}
+      redirect_to @bulk_upload, flash: { error: t('bulk_uploads.upload_error') }
     end
   end
 
   def create
-    redirect_to(:back) and return if params[:files].nil?
+    redirect_to(:back) && return unless params[:files].present?
 
-    results = params[:files].map { |file| CsvImporter.import(file.path) }
-    bulk_upload_possible = results.all? { |result| result[:successful] }
+    results = [] # store of all this BulkUpload's reports (successful and not)
+    blocking_files = [] # store of this BulkUpload's invalid files ( { filename:, error_messages: } )
 
-    if bulk_upload_possible
-      results.each { |result| BulkUpload.create(result) }
-      redirect_to bulk_uploads_path flash: {success: t("bulk_uploads.upload_successful")}
-    else
-      redirect_to BulkUpload.create(result), flash: {error: t("bulk_uploads.upload_error")}
+    ActiveRecord::Base.transaction do
+      params[:files].each do |file|
+        import = CsvImporter.import file.path
+        results << import
+
+        next if import[:successful]
+
+        blocking_files.push({
+                              filename: file.original_filename,
+                              error_messages: import[:happy_accidents].map { |hash| hash[:message] }.uniq
+                            })
+      end
+
+      raise ActiveRecord::Rollback unless blocking_files.empty?
+
+      # Only reached if no files are 'blocking'
+      results.each { |_result| BulkUpload.create results }
+      return redirect_to bulk_uploads_path, flash: { success: t('bulk_uploads.upload_successful') }
     end
+
+    error_message = generate_bulk_upload_error_message(blocking_files)
+
+    redirect_to bulk_uploads_path, flash: { error: error_message }
   end
 
   def destroy
-    bulk_upload = BulkUpload.find(params[:id]) or raise_404
+    (bulk_upload = BulkUpload.find(params[:id])) || raise_404
     bulk_upload.destroy
 
-    redirect_to action: :index, notice: "That bulk upload has been successfully deleted from the system. Thank you!"
+    redirect_to action: :index, notice: 'That bulk upload has been successfully deleted from the system. Thank you!'
+  end
+
+  private
+
+  def generate_bulk_upload_error_message(blocking_files)
+    error_message = t('bulk_uploads.upload_error')
+    tab = "&nbsp;" * 4
+
+
+    blocking_files.each do |file|
+      error_message += [
+        file[:filename],
+        file[:error_messages].map { |message| tab + message }.flatten
+      ].join("<br>")
+    end
+
+    error_message
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,16 @@ module ApplicationHelper
   def display_or_default(data, default="N/A")
     data.present? ? data : default
   end
+
+  # Bulk Upload index errors should persist so users can see the errors in their bulk upload
+  def flash_should_persist?
+    return false unless controller_name == 'bulk_uploads' && action_name == 'index'
+    return false unless flash.present?
+
+    begin
+      flash.any? { |key, val| key == 'error' }
+    rescue
+      false
+    end
+  end
 end

--- a/app/views/bulk_uploads/new.html.erb
+++ b/app/views/bulk_uploads/new.html.erb
@@ -14,7 +14,7 @@
 
 <%= form_tag bulk_uploads_path, multipart: true do %>
   <fieldset class="form__group">
-    <%= file_field_tag "file", required: true %>
+    <%= file_field_tag "files[]", multiple: true, required: true %>
   </fieldset>
 
   <%= submit_tag "Upload file", class: "button button-primary" %>

--- a/app/views/layouts/_flash_notification.html.erb
+++ b/app/views/layouts/_flash_notification.html.erb
@@ -1,6 +1,8 @@
 <% flash.each do |key, value| %>
-  <div class="alert alert-<%= key %>">
+  <div class="alert alert-<%= key %> <%= 'js-stay' if flash_should_persist? %>"
+  <% unless flash_should_persist? %>
     <p class="alert__close"><i class="fa fa-close"></i> Close</p>
+  <% end %>
     <h4 class="alert__title">
       <i class="fa fa-<%= alert_key_to_fa_icon(key) %>"></i> <%= key.titleize %>!
     </h4>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,8 +44,12 @@ en:
   bulk_uploads:
     delete_confirmation: "Are you sure you want to permanently delete this bulk upload (and its reports)?"
     upload_successful: "Thank you! Your bulk upload was successful"
-    upload_error: "Sorry, your bulk upload contains errors. Be sure to solve these issues before re-uploading the CSV file"
+    upload_error: |
+      One or more file(s) in your bulk upload is invalid. No reports have been created.<br><br>
+      
+      Below is a list of invalid files and possible reasons they were not valid.<br><br>
 
+      Please exclude or fix these files and try again.<br><br>
   helpers:
     page_entries_info:
       more_pages:

--- a/lib/modules/csv_converter.rb
+++ b/lib/modules/csv_converter.rb
@@ -13,6 +13,9 @@ class CsvConverter
   end
 
   def convert header, value
+    invalid_header_error_message = "'#{header}' is not a valid column header."
+    raise CsvConversionError, invalid_header_error_message unless self.class.columns.include? header
+
     if value && self.class.method_defined?(header)
       @has_data = true
       send(header.to_sym, value.strip)

--- a/lib/modules/csv_importer.rb
+++ b/lib/modules/csv_importer.rb
@@ -25,10 +25,10 @@ module CsvImporter
     end
 
     if happy_accidents.any?
-      {successful: false, happy_accidents: happy_accidents}
+      { successful: false, happy_accidents: happy_accidents }
     else
       ActiveRecord::Base.transaction { reports.each(&:save!) }
-      {successful: true, reports: reports}
+      { successful: true, reports: reports }
     end
   end
 

--- a/lib/modules/csv_importer.rb
+++ b/lib/modules/csv_importer.rb
@@ -2,6 +2,7 @@ require 'csv'
 
 module CsvImporter
   def self.import(csv_path)
+    # the presence of happy_accidents ultimately determines the value of the :successful key in the output hash
     happy_accidents = []
     reports = []
     line = 1
@@ -14,6 +15,7 @@ module CsvImporter
         begin
           converter.convert(header, value)
         rescue CsvConverter::CsvConversionError => e
+          # "happy_accidents" only added when this error is raised.
           happy_accidents << {line: line, column: column, header: header, message: e.message}
         end
 


### PR DESCRIPTION
This request is for a change requested by Kevin Barrett, to allow users to upload multiple CSVs at a time through the bulk upload form. This is now possible, but the system has been set up a little strangely. There are zero validations for Bulk Uploads and the association between reports and bulk uploads doesn't seem to be `dependent: :destroy`, so when you destroy a Bulk Upload, its reports remain.

None of the contributors to this repository are currently active in the organisation, as far as I can see, so I'm going to assign this PR to @lucacug.

Previous to this PR there was no `develop` branch in this repo, so I've created one based on `master`.