### PR TITLE
feat: rake task to update records with invalid data (WIP)

### DIFF
--- a/lib/modules/csv_converter.rb
+++ b/lib/modules/csv_converter.rb
@@ -23,6 +23,7 @@ class CsvConverter
   end
 
   def add_genus value, type
+    remove_non_breaking_spaces(value)
     @report.data["genera"][type] ||= []
 
     # Call find_genus using the species name. 
@@ -35,6 +36,7 @@ class CsvConverter
   end
 
   def answer question, value, page=nil
+    remove_non_breaking_spaces(value)
     if page
       @report.data["answers"][page] ||= [{}]
       @report.data["answers"][page][0][question] ||= {}
@@ -82,6 +84,7 @@ class CsvConverter
   end
 
   def find_genus value
+    remove_non_breaking_spaces(value)
     genera = {
       "Bonobo (Pan)" => "bonobo",
       "Chimpanzee (Pan)" => "chimpanzee",
@@ -182,5 +185,11 @@ class CsvConverter
 
   def self.columns
     CONVERSIONS.keys
+  end
+
+  def remove_non_breaking_spaces(value)
+    # Some file uploads contain data that has non-breaking sapces instead of spaces,
+    # so replace them with spaces.
+    value.gsub!(/\u00a0/," ") if value.is_a?(String)
   end
 end

--- a/lib/tasks/fix_invalid_data_from_imports.rake
+++ b/lib/tasks/fix_invalid_data_from_imports.rake
@@ -1,0 +1,49 @@
+desc 'Iterate over bjson data structure and replace all non-breaking spaces with spaces and remove all Â characters'
+task fix_invalid_data_from_imports: :environment do
+  Report.find_each do |report|
+    data = report.data
+    hash_iterator(data, report.id)
+    report.update(data: data)
+  end
+end
+
+def hash_iterator(hash, report_id)
+  keys = hash.keys
+  keys.each do |key|
+    value = hash[key]
+
+    if value.is_a?(Hash)
+      hash_iterator(value, report_id)
+    elsif value.is_a?(Array)
+      array_iterator(value, report_id)
+    elsif value.is_a?(String)
+      clean_string(value, report_id)
+    end
+  end
+end
+
+def array_iterator(value_array, report_id)
+  value_array.each do |value|
+    if value.is_a?(String)
+      clean_string(value, report_id)
+    elsif value.is_a?(Hash)
+      hash_iterator(value, report_id)
+    elsif value.is_a?(Array)
+      array_iterator(value, report_id)
+    end
+  end
+end
+
+def clean_string(value, report_id)
+  non_breaking_space = value =~ /\u00a0/
+  if non_breaking_space
+    puts "removing non-breaking space from #{value} on Report ##{report_id}"
+    value.gsub!(/\u00a0/," ")
+  end
+
+  invalid_character_index = value =~ /[Â]/
+  if invalid_character_index
+    puts "removing Â from #{value} on Report ##{report_id}"
+    value.slice!(invalid_character_index)
+  end
+end


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/bits-and-bugs/tickets/71

Fixes: "Unable to search records:
Whilst the database dashboard (the opening page of the database) lists 1856 records, when searching for ape-specific records (e.g gorillas alone, or chimpanzees, etc) only 745 records can be found. No records are listed when searching specifically for bonobos or gorillas. It appears that a search only reveals a portion of the chimpanzee and orang utan reports. No reports of body parts can be found. It is suspected that the number of 1856 may understate actual records."

We were importing non-breaking spaces, which look like spaces but aren't, so
```
from_params = params[:genus].first # "Gorilla (Gorilla)"

from_record = Report.find(3988).data['genera']['live'].first # "Gorilla (Gorilla)"

from_params == from_record # false

from_params.bytes # [71, 111, 114, 105, 108, 108, 97, 32,       40, 71, 111, 114, 105, 108, 108, 97, 41]
from_record.bytes # [71, 111, 114, 105, 108, 108, 97, 194, 160, 40, 71, 111, 114, 105, 108, 108, 97, 41]
                  #  G    O    R    I    L    L    A             (   G    O    R    I    L    L    A  )
```

We are also getting an Â character from somewhere, but Joe's recent fix will prevent that n future and hopefully get them to fix their encoding.

testing:
[grasp_20221001.zip](https://github.com/unepwcmc/grasp/files/9814626/grasp_20221001.zip)
import the the sql file attached by unzipping it then running ```sudo -u postgres psql grasp_development < PostgreSQL.sql``` or Mac equivalent.
run ```rake fix_invalid_data_from_imports```
log into app and try searching for gorillas, see some

does not fix the missing body parts issue, but if you add some in the app or upload some via csv you can search for them.